### PR TITLE
Fix text overflow

### DIFF
--- a/lib/ui_view/emotion_running_view.dart
+++ b/lib/ui_view/emotion_running_view.dart
@@ -48,13 +48,13 @@ class EmotionRunningView extends StatelessWidget {
                             children: <Widget>[
                               ClipRRect(
                                 borderRadius:
-                                BorderRadius.all(Radius.circular(8.0)),
+                                    BorderRadius.all(Radius.circular(8.0)),
                                 child: SizedBox(
                                   height: 74,
                                   child: AspectRatio(
                                     aspectRatio: 1.714,
-                                    child: Image.asset(
-                                        "assets/dexify/back.png"),
+                                    child:
+                                        Image.asset("assets/dexify/back.png"),
                                   ),
                                 ),
                               ),
@@ -63,23 +63,25 @@ class EmotionRunningView extends StatelessWidget {
                                 children: <Widget>[
                                   Row(
                                     children: <Widget>[
-                                      Padding(
-                                        padding: const EdgeInsets.only(
-                                          left: 100,
-                                          right: 16,
-                                          top: 16,
-                                        ),
-                                        child: Text(
-                                          "We have some motivation for you!",
-                                          textAlign: TextAlign.left,
-                                          style: TextStyle(
-                                            fontFamily:
-                                            DexifyAppTheme.fontName,
-                                            fontWeight: FontWeight.w500,
-                                            fontSize: 14,
-                                            letterSpacing: 0.0,
-                                            color:
-                                            DexifyAppTheme.nearlyDarkBlue,
+                                      Flexible(
+                                        child: Padding(
+                                          padding: const EdgeInsets.only(
+                                            left: 100,
+                                            right: 16,
+                                            top: 16,
+                                          ),
+                                          child: Text(
+                                            "We have some motivation for you!",
+                                            textAlign: TextAlign.left,
+                                            style: TextStyle(
+                                              fontFamily:
+                                                  DexifyAppTheme.fontName,
+                                              fontWeight: FontWeight.w500,
+                                              fontSize: 14,
+                                              letterSpacing: 0.0,
+                                              color:
+                                                  DexifyAppTheme.nearlyDarkBlue,
+                                            ),
                                           ),
                                         ),
                                       ),

--- a/lib/ui_view/running_view.dart
+++ b/lib/ui_view/running_view.dart
@@ -53,8 +53,8 @@ class RunningView extends StatelessWidget {
                                   height: 74,
                                   child: AspectRatio(
                                     aspectRatio: 1.714,
-                                    child: Image.asset(
-                                        "assets/dexify/back.png"),
+                                    child:
+                                        Image.asset("assets/dexify/back.png"),
                                   ),
                                 ),
                               ),
@@ -63,23 +63,25 @@ class RunningView extends StatelessWidget {
                                 children: <Widget>[
                                   Row(
                                     children: <Widget>[
-                                      Padding(
-                                        padding: const EdgeInsets.only(
-                                          left: 100,
-                                          right: 16,
-                                          top: 16,
-                                        ),
-                                        child: Text(
-                                          "You're doing great!",
-                                          textAlign: TextAlign.left,
-                                          style: TextStyle(
-                                            fontFamily:
-                                                DexifyAppTheme.fontName,
-                                            fontWeight: FontWeight.w500,
-                                            fontSize: 14,
-                                            letterSpacing: 0.0,
-                                            color:
-                                                DexifyAppTheme.nearlyDarkBlue,
+                                      Flexible(
+                                        child: Padding(
+                                          padding: const EdgeInsets.only(
+                                            left: 100,
+                                            right: 16,
+                                            top: 16,
+                                          ),
+                                          child: Text(
+                                            "You're doing great!",
+                                            textAlign: TextAlign.left,
+                                            style: TextStyle(
+                                              fontFamily:
+                                                  DexifyAppTheme.fontName,
+                                              fontWeight: FontWeight.w500,
+                                              fontSize: 14,
+                                              letterSpacing: 0.0,
+                                              color:
+                                                  DexifyAppTheme.nearlyDarkBlue,
+                                            ),
                                           ),
                                         ),
                                       ),


### PR DESCRIPTION
Fixed #4 

Changes: Fixed overflowing of text in the motivation and running pages. I couldn't find anywhere else in the app that would didn't correctly wrap text.

Screenshots of the change: 
![Screenshot_1601840677](https://user-images.githubusercontent.com/4750998/95025552-772ec100-0682-11eb-867f-f72b97ce40d4.png)

